### PR TITLE
feat: add patch to disable PCIe for Cubie A7A Router HAT compatibility

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 u-boot/0001-fix-disable-Allwinner-cross-toolchain.patch
+u-boot/0002-cubie-a7a-disable-pcie-for-router-hat-compatibility.patch

--- a/debian/patches/u-boot/0002-cubie-a7a-disable-pcie-for-router-hat-compatibility.patch
+++ b/debian/patches/u-boot/0002-cubie-a7a-disable-pcie-for-router-hat-compatibility.patch
@@ -1,0 +1,26 @@
+Description: Disable PCIe in U-Boot for Cubie A7A Router HAT compatibility
+ The Radxa Cubie A7A hangs during U-Boot when the Radxa Dual 2.5G Router HAT
+ is attached. The hang occurs after "pcie link up success" message during
+ ASM2806 PCIe switch enumeration.
+ .
+ This patch disables PCIe in U-Boot's device tree for the Cubie A7A board.
+ U-Boot doesn't need PCIe functionality for booting, and the Linux kernel
+ will re-initialize PCIe after boot with proper quirks for the ASM2806 switch.
+ .
+ Hardware affected:
+  - Board: Radxa Cubie A7A (Allwinner A733)
+  - HAT: Radxa Dual 2.5G Router HAT (ASMedia ASM2806 + 2x RTL8125B)
+--- a/device-a733/configs/cubie_a7a/uboot-board.dts
++++ b/device-a733/configs/cubie_a7a/uboot-board.dts
+@@ -857,7 +857,8 @@
+ };
+
+ &pcie_rc {
+-	status = "okay";
+-	pcie1v8-supply = <&reg_bldo1>;
+-	pcie3v3-supply = <&reg_dcdc1>;
++	/* Disabled to prevent U-Boot hang with Radxa Dual 2.5G Router HAT (ASM2806 PCIe switch).
++	 * Linux kernel will re-initialize PCIe after boot with proper quirks.
++	 */
++	status = "disabled";
+ };


### PR DESCRIPTION
The Radxa Cubie A7A board with Dual 2.5G Router HAT (ASM2806 PCIe switch)
hangs during U-Boot when the HAT is connected via PCIe FPC cable.

Problem:
- System boots successfully without the HAT attached
- With HAT attached, U-Boot hangs during PCIe initialization
- Serial log shows link training completes ("pcie link up success, 
  PCIe speed of Gen3"), but U-Boot freezes during device enumeration
- Hang occurs before downstream devices (RTL8125B NICs, M.2 slot) are detected
- Reproducible 100% of the time when HAT is connected

Root Cause:
The ASM2806 PCIe switch requires extended configuration space access and
specific initialization timing that U-Boot's generic PCIe driver does not
provide. The driver attempts to enumerate devices behind the switch but
cannot handle the switch's response properly, resulting in a hang.

Solution:
Disable PCIe initialization in U-Boot for the Cubie A7A board. The Linux
kernel's PCIe subsystem has proper quirks and timing support for the
ASM2806 switch and will successfully initialize the PCIe bus after boot.

This is a pragmatic workaround that:
- Allows U-Boot to boot successfully with the Router HAT attached
- Delegates full PCIe initialization to the kernel where proper driver
  support exists
- Does not affect boot behavior without the HAT attached